### PR TITLE
Fix NameError typo in grammar

### DIFF
--- a/odata_query/grammar.py
+++ b/odata_query/grammar.py
@@ -105,7 +105,7 @@ class ODataLexer(Lexer):
         Raises:
             TokenizingException
         """
-        raise exceptions.TokenizingException(text)
+        raise exceptions.TokenizingException(token)
 
     # NOTE: Ordering of tokens is important! Longer tokens preferably first
 


### PR DESCRIPTION
When the lexer encounters an unknown token, it'll raise a NameError instead of the intended TokenizingException because of this typo.

```
self = <odata_query.grammar.ODataLexer object at 0x7f7dca170e10>, token = Token(type='ERROR', value="'ROUNDHOUSE", lineno=1, index=15)

    def error(self, token):
        """
        Error handler during tokenization
    
        Args:
            token: The token that failed to tokenize.
        Raises:
            TokenizingException
        """
>       raise exceptions.TokenizingException(text)
E       NameError: name 'text' is not defined

../deps/venv/lib/python3.7/site-packages/odata_query/grammar.py:108: NameError

```