### PR TITLE
Fix ArgumentTypeException message

### DIFF
--- a/odata_query/exceptions.py
+++ b/odata_query/exceptions.py
@@ -108,9 +108,9 @@ class ArgumentTypeException(FunctionCallException):
         else:
             message = "Invalid argument type for function or operator."
         if expected_type:
-            message += " Expected {expected_type}"
+            message += f" Expected {expected_type}"
             if actual_type:
-                message += ", got {actual_type}"
+                message += f", got {actual_type}"
 
         super().__init__(message)
 


### PR DESCRIPTION
This change fixes ArgumentTypeException by using f-strings.

Code:
```python
from odata_query import ast
import odata_query.typing

odata_query.typing.typecheck(ast.Integer(42), ast.Identifier, "field")
```

Before:
```
ArgumentTypeException: Unsupported or invalid type for function or operator 'field' Expected {expected_type}, got {actual_type}
```

After:
```
ArgumentTypeException: Unsupported or invalid type for function or operator 'field' Expected Identifier, got Integer
```
