### PR TITLE
Parser; Add rudimentary OData namespace support.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,17 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_\ ,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+[Unreleased]
+------------
+
+Added
+^^^^^
+
+* Parser: Rudimentary OData namespace support.
+
+
 [0.4.2] - 2021-12-19
-----------
+--------------------
 
 Added
 ^^^^^

--- a/odata_query/ast.py
+++ b/odata_query/ast.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List as ListType, Optional, Tuple
 
 DURATION_PATTERN = re.compile(r"([+-])?P(\d+D)?(?:T(\d+H)?(\d+M)?(\d+(?:\.\d+)?S)?)?")
@@ -13,6 +13,7 @@ class _Node:
 @dataclass(frozen=True)
 class Identifier(_Node):
     name: str
+    namespace: Tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/odata_query/grammar.py
+++ b/odata_query/grammar.py
@@ -309,10 +309,11 @@ class ODataLexer(Lexer):
     ####################################################################################
     # Misc
     ####################################################################################
-    @_(r"[_a-z]\w{0,127}")
+    @_(r"[_a-z](?:\.?\w){0,127}")
     def ODATA_IDENTIFIER(self, t):
         ":meta private:"
-        t.value = ast.Identifier(t.value)
+        *ns, identifier = t.value.split(".")
+        t.value = ast.Identifier(identifier, tuple(ns))
         return t
 
     WS = _RWS

--- a/tests/integration/django/test_odata_to_django_q.py
+++ b/tests/integration/django/test_odata_to_django_q.py
@@ -21,6 +21,7 @@ def tz(offset: int) -> dt.tzinfo:
             "id eq a7af27e6-f5a0-11e9-9649-0a252986adba",
             Q(id__exact=uuid.UUID("a7af27e6-f5a0-11e9-9649-0a252986adba")),
         ),
+        ("my_app.id eq 1", Q(id__exact=Value(1))),
         (
             "id in (a7af27e6-f5a0-11e9-9649-0a252986adba, 800c56e4-354d-11eb-be38-3af9d323e83c)",
             Q(

--- a/tests/integration/sqlalchemy/test_odata_to_sqlalchemy_orm.py
+++ b/tests/integration/sqlalchemy/test_odata_to_sqlalchemy_orm.py
@@ -21,6 +21,7 @@ def tz(offset: int) -> dt.tzinfo:
             "id eq a7af27e6-f5a0-11e9-9649-0a252986adba",
             BlogPost.id == "a7af27e6-f5a0-11e9-9649-0a252986adba",
         ),
+        ("my_app.id eq 1", BlogPost.id == 1),
         (
             "id in (a7af27e6-f5a0-11e9-9649-0a252986adba, 800c56e4-354d-11eb-be38-3af9d323e83c)",
             BlogPost.id.in_(

--- a/tests/unit/test_odata_parser.py
+++ b/tests/unit/test_odata_parser.py
@@ -133,6 +133,8 @@ def test_list_parsing(value: str):
     "value, expected_type",
     [
         ("meter_id", ast.Identifier),
+        ("nammespace.meter_id", ast.Identifier),
+        ("multiple.namespace.meter_id", ast.Identifier),
         ("_id", ast.Identifier),
         ("_123", ast.Identifier),
         ("ab123", ast.Identifier),
@@ -153,6 +155,23 @@ def test_member_expression_parsing(value: str, expected_type: type):
         (
             "meter_id eq '1'",
             ast.Compare(ast.Eq(), ast.Identifier("meter_id"), ast.String("1")),
+        ),
+        (
+            "namespace.meter_id eq 1",
+            ast.Compare(
+                ast.Eq(), ast.Identifier("meter_id", ("namespace",)), ast.Integer("1")
+            ),
+        ),
+        (
+            "ns1.ns2.meter_id eq 1",
+            ast.Compare(
+                ast.Eq(),
+                ast.Identifier(
+                    "meter_id",
+                    ("ns1", "ns2"),
+                ),
+                ast.Integer("1"),
+            ),
         ),
         (
             "meter_id eq 'o''reilly'''",


### PR DESCRIPTION
As discussed in #4.

This PR adds rudimentary support to parse OData namespaces. 
It simply stores the namespace as part of the `Identifier` node, but doesn't do anything with it yet.