### PR TITLE
feat(rs): experiment basic parsing with nom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,46 +15,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chumsky"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23170228b96236b5a7299057ac284a321457700bc8c41a4476052f0f4ba5349d"
-dependencies = [
- "hashbrown",
- "stacker",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "indoc"
@@ -90,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,10 +58,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "odata-query"
 version = "0.1.0"
 dependencies = [
- "chumsky",
+ "nom",
  "pyo3",
 ]
 
@@ -142,15 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -244,19 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,40 +237,6 @@ name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ name = "_odata_query"
 crate-type = ["cdylib"]
 
 [dependencies]
-chumsky = "0.9.2"
+nom = "7.1.3"
 pyo3 = "0.18.3"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, PartialEq, Clone)]
+pub enum Literal {
+    // primitiveLiteral
+    Null,
+    Boolean(bool),
+    Date(String),
+    DateTimeOffset(String),
+    Time(String),
+    Float(f64), // decimal, double, single
+    GUID(String),
+    Integer(i64), // sbyte, byte, int16, int32 ,int64
+    String(String),
+    Duration(String),
+    Binary(Box<[u8]>),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum CommonExpr {
+    Literal(Literal),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,19 @@
 use pyo3::prelude::*;
 
+mod ast;
+mod parser;
+
 /// Formats the sum of two numbers as string.
 #[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
+fn parse_odata(odata_query: &str) -> PyResult<bool> {
+    let ast = parser::parse(odata_query);
+    println!("{:?}", ast);
+    Ok(true)
 }
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _odata_query(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_odata, m)?)?;
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,112 @@
+use crate::ast::{CommonExpr, Literal};
+use nom::branch::alt;
+use nom::bytes::complete::{tag, tag_no_case};
+use nom::character::complete::{char, digit1, one_of};
+use nom::combinator::{cut, map, opt, recognize, value, verify};
+use nom::error::{Error, ParseError};
+use nom::sequence::{pair, tuple};
+use nom::IResult;
+use nom::ParseTo;
+
+pub fn parse_float(inp: &str) -> IResult<&str, f64> {
+    let (i, float_str) = recognize(verify(
+        tuple((
+            opt(one_of("+-")),
+            digit1,
+            opt(pair(char('.'), opt(digit1))),
+            opt(tuple((one_of("eE"), opt(one_of("+-")), cut(digit1)))),
+        )),
+        // We need at least a fraction or an exponent for a valid float
+        |(_, _, frac, exp)| frac.is_some() || exp.is_some(),
+    ))(inp)?;
+
+    match float_str.parse_to() {
+        Some(f) => Ok((i, f)),
+        None => Err(nom::Err::Error(Error::from_error_kind(
+            i,
+            nom::error::ErrorKind::Float,
+        ))),
+    }
+}
+
+pub fn parse_literal(inp: &str) -> IResult<&str, Literal> {
+    let null = value(Literal::Null, tag("null"));
+
+    let bool = alt((
+        value(Literal::Boolean(true), tag_no_case("true")),
+        value(Literal::Boolean(false), tag_no_case("false")),
+    ));
+
+    let int = map(nom::character::complete::i64, Literal::Integer);
+    let float = alt((
+        map(parse_float, Literal::Float),
+        value(Literal::Float(f64::NAN), tag("NaN")),
+        value(Literal::Float(f64::INFINITY), tag("INF")),
+        value(Literal::Float(f64::NEG_INFINITY), tag("-INF")),
+    ));
+
+    alt((null, bool, float, int))(inp)
+}
+
+pub fn parse(odata_query: &str) -> IResult<&str, CommonExpr> {
+    (map(parse_literal, CommonExpr::Literal))(odata_query)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_parsed_to<T>(result: IResult<&str, T>, exp: T)
+    where
+        T: std::fmt::Debug + std::cmp::PartialEq,
+    {
+        assert!(result.is_ok());
+        match result {
+            Ok((rest, node)) => {
+                assert!(rest.is_empty(), "Unparsed input: {rest}");
+                assert_eq!(node, exp);
+            }
+            _ => panic!("Shouldn't occur"),
+        }
+    }
+
+    #[test]
+    fn parse_null() {
+        assert_parsed_to(parse_literal("null"), Literal::Null);
+    }
+
+    #[test]
+    fn parse_boolean() {
+        assert_parsed_to(parse_literal("true"), Literal::Boolean(true));
+        assert_parsed_to(parse_literal("True"), Literal::Boolean(true));
+        assert_parsed_to(parse_literal("false"), Literal::Boolean(false));
+        assert_parsed_to(parse_literal("False"), Literal::Boolean(false));
+    }
+
+    #[test]
+    fn parse_integer() {
+        assert_parsed_to(parse_literal("0"), Literal::Integer(0));
+        assert_parsed_to(parse_literal("123456789"), Literal::Integer(123456789));
+        assert_parsed_to(parse_literal("+123456789"), Literal::Integer(123456789));
+        assert_parsed_to(parse_literal("-123456789"), Literal::Integer(-123456789));
+    }
+
+    #[test]
+    fn parse_float() {
+        assert_parsed_to(parse_literal("0.1"), Literal::Float(0.1));
+        assert_parsed_to(parse_literal("-0.1"), Literal::Float(-0.1));
+        assert_parsed_to(parse_literal("1e10"), Literal::Float(1e10));
+        assert_parsed_to(parse_literal("-1e10"), Literal::Float(-1e10));
+        assert_parsed_to(parse_literal("1e-10"), Literal::Float(1e-10));
+        assert_parsed_to(parse_literal("1E-10"), Literal::Float(1e-10));
+        assert_parsed_to(parse_literal("123.456e10"), Literal::Float(123.456e10));
+        assert_parsed_to(parse_literal("INF"), Literal::Float(f64::INFINITY));
+        assert_parsed_to(parse_literal("-INF"), Literal::Float(f64::NEG_INFINITY));
+
+        // NaN never tests equal:
+        match parse_literal("NaN") {
+            Ok(("", Literal::Float(nan))) => assert!(nan.is_nan()),
+            _ => assert!(false),
+        };
+    }
+}


### PR DESCRIPTION
Builds upon original PyO3 boilerplate introduced in fa51f2926eaf987558981d6d8f729017a2532943

This is a basic parser built with [nom](https://github.com/rust-bakery/nom), currently able to parse a subset of primitive literals in OData ([grammar reference](https://docs.oasis-open.org/odata/odata/v4.01/cs01/abnf/odata-abnf-construction-rules.txt)).

NOTE: This is the first time someone reviews my Rust code, and my first time building a parser with `nom`. All feedback and nitpicks welcome.