### PR TITLE
Rs: parse string, GUID and binary literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +83,7 @@ dependencies = [
 name = "odata-query"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "nom",
  "pyo3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ name = "_odata_query"
 crate-type = ["cdylib"]
 
 [dependencies]
+base64 = "0.21.2"
 nom = "7.1.3"
 pyo3 = "0.18.3"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,7 +11,7 @@ pub enum Literal {
     Integer(i64), // sbyte, byte, int16, int32 ,int64
     String(String),
     Duration(String),
-    Binary(Box<[u8]>),
+    Binary(Vec<u8>),
 }
 
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
Implements parsing of:
- String literals (2a66cf295f92c16e8ef58a66d15fe219b64f1b76)
- GUID literals (b305aa3b3b62efc11dec9a63397523aaca76d279)
- Binary literals (dc79216a7bd2b34b08206dc44123686a71748b5e)