### PR TITLE
Allow odata-query defined SQLAlchemy functions to inherit cache and not clash with others

### DIFF
--- a/odata_query/sqlalchemy/functions_ext.py
+++ b/odata_query/sqlalchemy/functions_ext.py
@@ -4,35 +4,44 @@ from sqlalchemy.types import Integer, String
 
 class strpos(GenericFunction):
     type = Integer
+    package = "odata"
 
 
 class substr(GenericFunction):
     type = String
+    package = "odata"
 
 
 class lower(GenericFunction):
     type = String
+    package = "odata"
 
 
 class upper(GenericFunction):
     type = String
+    package = "odata"
 
 
 class ltrim(GenericFunction):
     type = String
+    package = "odata"
 
 
 class rtrim(GenericFunction):
     type = String
+    package = "odata"
 
 
 class ceil(GenericFunction):
     type = Integer
+    package = "odata"
 
 
 class floor(GenericFunction):
     type = Integer
+    package = "odata"
 
 
 class round(GenericFunction):
     type = Integer
+    package = "odata"

--- a/odata_query/sqlalchemy/functions_ext.py
+++ b/odata_query/sqlalchemy/functions_ext.py
@@ -5,43 +5,52 @@ from sqlalchemy.types import Integer, String
 class strpos(GenericFunction):
     type = Integer
     package = "odata"
+    inherit_cache = True
 
 
 class substr(GenericFunction):
     type = String
     package = "odata"
+    inherit_cache = True
 
 
 class lower(GenericFunction):
     type = String
     package = "odata"
+    inherit_cache = True
 
 
 class upper(GenericFunction):
     type = String
     package = "odata"
+    inherit_cache = True
 
 
 class ltrim(GenericFunction):
     type = String
     package = "odata"
+    inherit_cache = True
 
 
 class rtrim(GenericFunction):
     type = String
     package = "odata"
+    inherit_cache = True
 
 
 class ceil(GenericFunction):
     type = Integer
     package = "odata"
+    inherit_cache = True
 
 
 class floor(GenericFunction):
     type = Integer
     package = "odata"
+    inherit_cache = True
 
 
 class round(GenericFunction):
     type = Integer
     package = "odata"
+    inherit_cache = True


### PR DESCRIPTION
Changes as described in [the issue I raised](https://github.com/gorilla-co/odata-query/issues/44).