### PR TITLE
chore(typing): log `debug` instead of `warning` when type inference fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 [Unreleased]
 ---------------------
 
+Changed
+^^^^^^^
+
+* Log ``debug`` instead of ``warning`` when type inference fails.
+
 
 [0.10.0] - 2024-01-21
 ---------------------

--- a/odata_query/typing.py
+++ b/odata_query/typing.py
@@ -51,7 +51,7 @@ def infer_type(node: ast._Node) -> Optional[Type[ast._Node]]:
     if isinstance(node, ast.Call):
         return infer_return_type(node)
 
-    log.warning("Failed to infer type for %s", node)
+    log.debug("Failed to infer type for %s", node)
     return None
 
 


### PR DESCRIPTION
ref: #55