### PR TITLE
added about_equal function for sqlalchemy

### DIFF
--- a/odata_query/grammar.py
+++ b/odata_query/grammar.py
@@ -52,6 +52,7 @@ ODATA_FUNCTIONS = {
     "round": 1,
     "floor": 1,
     "ceiling": 1,
+    "aboutequal": 3,
     # Geo functions
     "geo.distance": 2,
     "geo.length": 1,

--- a/odata_query/sqlalchemy/common.py
+++ b/odata_query/sqlalchemy/common.py
@@ -2,6 +2,7 @@ import operator
 from typing import Any, Callable, Optional, Union
 
 from sqlalchemy.sql import functions
+from sqlalchemy import func
 from sqlalchemy.sql.expression import (
     BinaryExpression,
     BindParameter,
@@ -301,6 +302,13 @@ class _CommonVisitors(visitor.NodeVisitor):
     def func_floor(self, field: ast._Node) -> functions.Function:
         ":meta private:"
         return functions_ext.floor(self.visit(field))
+    
+    def func_aboutequal(self, field: ast._Node, value: ast._Node, tolerance: ast._Node) -> functions.Function:
+        ":meta private:"
+        field = self.visit(field)
+        value = self.visit(value)
+        tolerance = self.visit(tolerance)
+        return operator.lt(func.abs(operator.sub(field, value)), tolerance)  
 
     def func_round(self, field: ast._Node) -> functions.Function:
         ":meta private:"

--- a/odata_query/typing.py
+++ b/odata_query/typing.py
@@ -95,6 +95,7 @@ def infer_return_type(node: ast.Call) -> Optional[Type[ast._Node]]:
         "ceiling",
         "floor",
         "round",
+        "aboutequal",
         "geo.distance",
         "geo.length",
     ):


### PR DESCRIPTION
I created this PR mostly to share my code and not so much as to have it actually implemented into the master. I the knowledge to write the same implementation for the SQL and Django backends and I realize that that is a requirement for this functionality to be considered. I hope someone will be able to add this functionality for those backends as well. 

For now I will just proceed using

```python

from odata_query.grammar import ODataParser, ODataLexer, ODATA_FUNCTIONS
from odata_query.sqlalchemy.common import _CommonVisitors
from odata_query import ast
from sqlalchemy import func
from sqlalchemy.sql import functions
import operator

ODATA_FUNCTIONS['aboutequal'] = 3

def func_aboutequal(self, field: ast._Node, value: ast._Node, tolerance: ast._Node) -> functions.Function:
    ":meta private:"
    field = self.visit(field)
    value = self.visit(value)
    tolerance = self.visit(tolerance)
    return operator.lt(func.abs(operator.sub(field, value)), tolerance)  

_CommonVisitors.func_aboutequal = func_aboutequal
```