### PR TITLE
fix: Add UUID/GUID support in contains, startswith, and endswith func…

### DIFF
--- a/odata_query/django/django_q.py
+++ b/odata_query/django/django_q.py
@@ -467,7 +467,7 @@ class AstToDjangoQVisitor(visitor.NodeVisitor):
     ) -> Expression:
         ":meta private:"
         typing.typecheck(field, (ast.Identifier, ast.String), "field")
-        typing.typecheck(substr, ast.String, "substring")
+        typing.typecheck(substr, (ast.String, ast.GUID), "substring")
 
         return django_func(self.visit(field), self.visit(substr))
 

--- a/odata_query/sql/base.py
+++ b/odata_query/sql/base.py
@@ -256,8 +256,8 @@ class AstToSqlVisitor(visitor.NodeVisitor):
         args_sql = [self.visit(arg) for arg in args]
         inferred_type = [typing.infer_type(arg) for arg in args]
 
-        # If any of the inputs is a string or default, assume str-contains:
-        if any(typ is ast.String for typ in inferred_type) or all(
+        # If any of the inputs is a string, GUID, or default, assume str-contains:
+        if any(typ in (ast.String, ast.GUID) for typ in inferred_type) or all(
             typ is None for typ in inferred_type
         ):
             pattern = self._to_pattern(args[1], prefix="%", suffix="%")
@@ -274,8 +274,8 @@ class AstToSqlVisitor(visitor.NodeVisitor):
         args_sql = [self.visit(arg) for arg in args]
         inferred_type = [typing.infer_type(arg) for arg in args]
 
-        # If any of the inputs is a string or default, assume str-endswith:
-        if any(typ is ast.String for typ in inferred_type) or all(
+        # If any of the inputs is a string, GUID, or default, assume str-endswith:
+        if any(typ in (ast.String, ast.GUID) for typ in inferred_type) or all(
             typ is None for typ in inferred_type
         ):
             pattern = self._to_pattern(args[1], prefix="%")
@@ -326,8 +326,8 @@ class AstToSqlVisitor(visitor.NodeVisitor):
         args_sql = [self.visit(arg) for arg in args]
         inferred_type = [typing.infer_type(arg) for arg in args]
 
-        # If any of the inputs is a string or default, assume str-startswith:
-        if any(typ is ast.String for typ in inferred_type) or all(
+        # If any of the inputs is a string, GUID, or default, assume str-startswith:
+        if any(typ in (ast.String, ast.GUID) for typ in inferred_type) or all(
             typ is None for typ in inferred_type
         ):
             pattern = self._to_pattern(args[1], suffix="%")

--- a/odata_query/sqlalchemy/common.py
+++ b/odata_query/sqlalchemy/common.py
@@ -311,7 +311,7 @@ class _CommonVisitors(visitor.NodeVisitor):
     ) -> ClauseElement:
         ":meta private:"
         typing.typecheck(field, (ast.Identifier, ast.String), "field")
-        typing.typecheck(substr, ast.String, "substring")
+        typing.typecheck(substr, (ast.String, ast.GUID), "substring")
 
         identifier = self.visit(field)
         substring = self.visit(substr)

--- a/tests/unit/sql/test_ast_to_sqlite.py
+++ b/tests/unit/sql/test_ast_to_sqlite.py
@@ -139,6 +139,22 @@ def test_ast_to_sql(ast_input: ast._Node, sql_expected: str):
         ("round", [ast.Float("123.12")], "TRUNC(123.12 + 0.5)"),
         ("floor", [ast.Float("123.12")], "FLOOR(123.12)"),
         ("ceiling", [ast.Float("123.12")], "CEILING(123.12)"),
+        # Test GUID support in string functions
+        (
+            "contains",
+            [ast.Identifier("name"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+            "\"name\" LIKE '%7a7f024c-d21f-40b1-8296-b664a0de278c%'",
+        ),
+        (
+            "startswith",
+            [ast.Identifier("name"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+            "\"name\" LIKE '7a7f024c-d21f-40b1-8296-b664a0de278c%'",
+        ),
+        (
+            "endswith",
+            [ast.Identifier("name"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+            "\"name\" LIKE '%7a7f024c-d21f-40b1-8296-b664a0de278c'",
+        ),
     ],
 )
 def test_ast_to_sql_functions(func_name: str, args: List[ast._Node], sql_expected: str):

--- a/tests/unit/test_guid_in_functions.py
+++ b/tests/unit/test_guid_in_functions.py
@@ -1,0 +1,53 @@
+"""Tests for GUID support in string functions like contains, startswith, endswith."""
+import pytest
+
+from odata_query import ast, typing
+
+
+class TestGUIDInStringFunctions:
+    """Test that GUID literals can be used in string matching functions."""
+
+    def test_contains_with_guid_infers_boolean(self):
+        """Test that contains() with a GUID parameter returns Boolean type."""
+        node = ast.Call(
+            ast.Identifier("contains"),
+            [ast.Identifier("field"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+        )
+        result = typing.infer_type(node)
+        assert result is ast.Boolean
+
+    def test_startswith_with_guid_infers_boolean(self):
+        """Test that startswith() with a GUID parameter returns Boolean type."""
+        node = ast.Call(
+            ast.Identifier("startswith"),
+            [ast.Identifier("field"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+        )
+        result = typing.infer_type(node)
+        assert result is ast.Boolean
+
+    def test_endswith_with_guid_infers_boolean(self):
+        """Test that endswith() with a GUID parameter returns Boolean type."""
+        node = ast.Call(
+            ast.Identifier("endswith"),
+            [ast.Identifier("field"), ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")],
+        )
+        result = typing.infer_type(node)
+        assert result is ast.Boolean
+
+    def test_guid_literal_infers_as_guid_type(self):
+        """Test that GUID literals are properly typed."""
+        node = ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")
+        result = typing.infer_type(node)
+        assert result is ast.GUID
+
+    def test_typecheck_accepts_guid_for_substring_param(self):
+        """Test that typecheck accepts GUID types for substring parameters."""
+        guid_node = ast.GUID("7a7f024c-d21f-40b1-8296-b664a0de278c")
+        # Should not raise an exception
+        typing.typecheck(guid_node, (ast.String, ast.GUID), "substring")
+
+    def test_typecheck_accepts_string_for_substring_param(self):
+        """Test that typecheck still accepts String types for substring parameters."""
+        string_node = ast.String("test")
+        # Should not raise an exception
+        typing.typecheck(string_node, (ast.String, ast.GUID), "substring")


### PR DESCRIPTION
This pull request adds support for using GUID literals in string matching functions (`contains`, `startswith`, `endswith`) across the codebase. The main changes ensure that GUIDs are accepted and handled similarly to strings in these functions, and comprehensive tests are added to verify correct typing and SQL translation.

Enhancements for GUID support in string functions:

* Updated type checking in `_substr_function` for both Django and SQLAlchemy backends to accept `ast.GUID` as a valid substring parameter alongside `ast.String`. [[1]](diffhunk://#diff-92e398a5ca7e19dbedd27449cbfc2c58b867e6561ae79e5790b3025a3ae6ddbaL470-R470) [[2]](diffhunk://#diff-4aaa47a598417af7eb881326e89a9ad15f26fe2385a5f185a271ade88c89d538L314-R314)
* Modified SQL translation logic in `sqlfunc_contains`, `sqlfunc_startswith`, and `sqlfunc_endswith` in `odata_query/sql/base.py` to treat GUIDs as valid types for string matching, ensuring correct SQL generation. [[1]](diffhunk://#diff-a64723a132f97c210dfa214d75691584b71e6aeccf420c530126b293d41e1adeL259-R260) [[2]](diffhunk://#diff-a64723a132f97c210dfa214d75691584b71e6aeccf420c530126b293d41e1adeL277-R278) [[3]](diffhunk://#diff-a64723a132f97c210dfa214d75691584b71e6aeccf420c530126b293d41e1adeL329-R330)

Testing improvements:

* Added new unit tests in `tests/unit/test_guid_in_functions.py` to verify that GUIDs are properly typed, accepted in string functions, and result in correct boolean inference.
* Expanded SQL translation tests in `tests/unit/sql/test_ast_to_sqlite.py` to include cases where GUIDs are used in string functions, confirming correct SQL output.